### PR TITLE
fix collapseDuplicates bug when only 1 sequence is left in a vjl group

### DIFF
--- a/R/Sequence.R
+++ b/R/Sequence.R
@@ -327,7 +327,7 @@ collapseDuplicates <- function(data, id="sequence_id", seq="sequence_alignment",
     
     # Exclude ambiguous sequences from clustering
     if (!dry & discard_count > 0) {
-            d_mat <- d_mat[-ambig_rows, -ambig_rows]
+            d_mat <- d_mat[-ambig_rows, -ambig_rows, drop = FALSE]  # 'drop = FALSE' to keep dataframe structure if only one sequence is left 
             data <- data[!data_ambig_rows,]
     }
     


### PR DESCRIPTION
Solved the problem reported by a nf-core/airrflow user in airrflow issues.
https://github.com/nf-core/airrflow/issues/420