### PR TITLE
Pairwise distance performance

### DIFF
--- a/src/RcppDistance.cpp
+++ b/src/RcppDistance.cpp
@@ -1,9 +1,94 @@
 #include <Rcpp.h>
 #include <iostream>
 #include <map>
+#include <vector>
 
 using namespace Rcpp;
 // [[Rcpp::plugins(cpp11)]]
+
+namespace {
+
+void buildDistLookupMaps(const NumericMatrix& dist_mat,
+                         std::map<std::string, int>& rows_map,
+                         std::map<std::string, int>& cols_map) {
+    List dist_mat_dims = dist_mat.attr("dimnames");
+    CharacterVector dist_mat_rownames = dist_mat_dims[0];
+    CharacterVector dist_mat_colnames = dist_mat_dims[1];
+
+    int num_rows = dist_mat_rownames.size();
+    int num_cols = dist_mat_colnames.size();
+
+    rows_map.clear();
+    cols_map.clear();
+
+    for (int i = 0; i < num_rows; i++) {
+        std::string this_row = as<std::string>(dist_mat_rownames[i]);
+        if (this_row.empty()) {
+            throw std::range_error("Empty row name in dist_mat.");
+        }
+        rows_map[this_row] = i;
+    }
+
+    for (int i = 0; i < num_cols; i++) {
+        std::string this_col = as<std::string>(dist_mat_colnames[i]);
+        if (this_col.empty()) {
+            throw std::range_error("Empty column name in dist_mat.");
+        }
+        cols_map[this_col] = i;
+    }
+}
+
+double seqDistWithMaps(const std::string& seq1,
+                       const std::string& seq2,
+                       const NumericMatrix& dist_mat,
+                       const std::map<std::string, int>& rows_map,
+                       const std::map<std::string, int>& cols_map) {
+    int len_seq1 = seq1.size();
+    int len_seq2 = seq2.size();
+
+    if (len_seq1 != len_seq2) {
+        throw std::range_error("Sequences of different length.");
+    }
+
+    int d_seen = 0;
+    int indels = 0;
+    double d_sum = 0;
+
+    for (int i = 0; i < len_seq1; i++) {
+        int r_idx;
+        std::string row_string;
+        row_string += static_cast<char>(seq1[i]);
+        auto search_row = rows_map.find(row_string);
+        if (search_row != rows_map.end()) {
+            r_idx = search_row->second;
+        } else {
+            throw std::range_error("Character not found in dist_mat.");
+        }
+
+        int c_idx;
+        std::string col_string;
+        col_string += static_cast<char>(seq2[i]);
+        auto search_col = cols_map.find(col_string);
+        if (search_col != cols_map.end()) {
+            c_idx = search_col->second;
+        } else {
+            throw std::range_error("Character not found in dist_mat.");
+        }
+
+        double d_i = dist_mat(r_idx, c_idx);
+
+        if (d_i > 0) {
+            d_sum = d_sum + d_i;
+        } else if ((d_i == -1) & (d_seen != -1)) {
+            indels++;
+        }
+        d_seen = d_i;
+    }
+
+    return d_sum + indels;
+}
+
+} // namespace
 
 
 //' Test DNA sequences for equality.
@@ -136,94 +221,10 @@ LogicalMatrix pairwiseEqual(StringVector seq) {
 // [[Rcpp::export]]
 double seqDistRcpp(std::string seq1, std::string seq2, 
                    NumericMatrix dist_mat) {
-
-    // Check that seq1 and seq2 have same length
-    int len_seq1 = seq1.length();
-    int len_seq2 = seq2.length();
-    
-    if (len_seq1 != len_seq2) {
-        throw std::range_error("Sequences of different length.");  
-    }
-    
-    int len_seqs = len_seq1;
-    
-    List dist_mat_dims = dist_mat.attr("dimnames");
-    //print (dist_mat_dims);
-    CharacterVector dist_mat_rownames = dist_mat_dims[0];
-    CharacterVector dist_mat_colnames = dist_mat_dims[1];
-    int num_rows = dist_mat_rownames.size();
-    int num_cols = dist_mat_colnames.size();
-    
-    List row_key_idx;
-    List col_key_idx;
-    
     std::map<std::string, int> rows_map;
     std::map<std::string, int> cols_map;
-    
-    for (int i = 0; i < num_rows; i++)
-    {
-        //const char *this_col = dist_mat_colnames[i].c_str();
-        std::string this_row = as<std::string>(dist_mat_rownames[i]);
-        rows_map[this_row] = i;
-    }  
-    
-    for (int i = 0; i < num_cols; i++)
-    {
-        //const char *this_col = dist_mat_colnames[i].c_str();
-        std::string this_col = as<std::string>(dist_mat_colnames[i]);
-        cols_map[this_col] = i;
-    } 
-    
-    int d_seen = 0;
-    int indels = 0;
-    // sum(d[d>0])
-    double d_sum = 0;
-    
-    for (int i = 0; i < len_seqs; i++)
-    {
-        // find row index
-        int row_idx;
-        char row_char = (char)seq1[i];
-        std::string row_string;
-        row_string+=row_char;
-        auto search_row = rows_map.find(row_string);
-        if(search_row != rows_map.end()) {
-            row_idx = search_row->second;
-        }
-        else {
-            throw std::range_error("Character not found in dist_mat.");  
-        }
-        
-        // find col index
-        int col_idx;
-        char col_char = (char)seq2[i];
-        std::string col_string;
-        col_string+=col_char;
-        auto search_col = cols_map.find(col_string);
-        if(search_col != cols_map.end()) {
-            col_idx = search_col->second;
-        }
-        else {
-            throw std::range_error("Character not found in dist_mat.");  
-        }    
-        
-        // distance for current i
-        double d_i = dist_mat(row_idx, col_idx);
-        
-        if (d_i > 0){
-            // Sum distance
-            d_sum = d_sum + d_i;
-        } 
-        else if ( (d_i == -1 ) &  (d_seen != -1) )
-        {
-            // Count indel
-            indels++;
-        }  
-        d_seen = d_i;
-    }
-    
-    double distance = d_sum + indels;
-    return (distance);
+    buildDistLookupMaps(dist_mat, rows_map, cols_map);
+    return seqDistWithMaps(seq1, seq2, dist_mat, rows_map, cols_map);
 }
 
 
@@ -232,15 +233,23 @@ double seqDistRcpp(std::string seq1, std::string seq2,
 NumericMatrix pairwiseDistRcpp(StringVector seq, NumericMatrix dist_mat) {
     // allocate the matrix we will return
     NumericMatrix rmat(seq.length(), seq.length());
+
+    int n_seq = seq.length();
+    std::vector<std::string> seq_cpp(n_seq);
+    for (int i = 0; i < n_seq; i++) {
+        seq_cpp[i] = as<std::string>(seq[i]);
+    }
+
+    std::map<std::string, int> rows_map;
+    std::map<std::string, int> cols_map;
+    buildDistLookupMaps(dist_mat, rows_map, cols_map);
     
     for (int i = 0; i < rmat.nrow(); i++) {
         for (int j = 0; j < i; j++) {
-            
-            // check seq equal
-            std::string row_seq = as<std::string>(seq[i]);
-            std::string col_seq = as<std::string>(seq[j]);
-            
-            double distance = seqDistRcpp(row_seq, col_seq, dist_mat);
+            const std::string& row_seq = seq_cpp[i];
+            const std::string& col_seq = seq_cpp[j];
+
+            double distance = seqDistWithMaps(row_seq, col_seq, dist_mat, rows_map, cols_map);
             
             // write to output matrix
             rmat(i,j) = distance;
@@ -262,13 +271,23 @@ NumericMatrix nonsquareDistRcpp(StringVector seq, NumericVector indx, NumericMat
 {
     // defien variables
     int m, n, i, j;
-    std::string row_seq, col_seq;
     // extract the sizes. Note: This should be satisfied (n<=m)
     m = indx.size(); //number of rows
     n = seq.size();  //number of columns
+
+    std::vector<std::string> seq_cpp(n);
+    for (i = 0; i < n; i++) {
+        seq_cpp[i] = as<std::string>(seq[i]);
+    }
+
     // allocate the main matrix
     NumericMatrix rmat(m,n);
     std::fill(rmat.begin(), rmat.end(), NA_REAL);
+
+    std::map<std::string, int> rows_map;
+    std::map<std::string, int> cols_map;
+    buildDistLookupMaps(dist_mat, rows_map, cols_map);
+
     // sort and push indices back by 1 to match c++ indexing
     std::sort(indx.begin(), indx.end());
     indx = indx - 1;
@@ -279,13 +298,14 @@ NumericMatrix nonsquareDistRcpp(StringVector seq, NumericVector indx, NumericMat
     }
     // begin filling rmat
     for (i = 0; i < m; i++) {
-        row_seq = as<std::string>(seq[indx[i]]);     //row sequence 
+        int row_id = indx[i];
+        const std::string& row_seq = seq_cpp[row_id];
         for (j = 0; j < n; j++) {
             if (!R_IsNA(rmat(i,j))) continue;
-            if (indx[i] == j) rmat(i,j) = 0; 
+            if (row_id == j) rmat(i,j) = 0;
             else {
-                col_seq = as<std::string>(seq[j]); //col sequence
-                rmat(i,j) = seqDistRcpp(row_seq, col_seq, dist_mat);
+                const std::string& col_seq = seq_cpp[j];
+                rmat(i,j) = seqDistWithMaps(row_seq, col_seq, dist_mat, rows_map, cols_map);
                 if (pos[j] < m) rmat(pos[j],indx[i]) = rmat(i,j);
             }
         }

--- a/src/RcppDistance.cpp
+++ b/src/RcppDistance.cpp
@@ -1,6 +1,6 @@
 #include <Rcpp.h>
 #include <iostream>
-#include <map>
+#include <array>
 #include <vector>
 
 using namespace Rcpp;
@@ -8,9 +8,9 @@ using namespace Rcpp;
 
 namespace {
 
-void buildDistLookupMaps(const NumericMatrix& dist_mat,
-                         std::map<std::string, int>& rows_map,
-                         std::map<std::string, int>& cols_map) {
+void buildDistLookup(const NumericMatrix& dist_mat,
+                     std::array<int, 256>& row_idx,
+                     std::array<int, 256>& col_idx) {
     List dist_mat_dims = dist_mat.attr("dimnames");
     CharacterVector dist_mat_rownames = dist_mat_dims[0];
     CharacterVector dist_mat_colnames = dist_mat_dims[1];
@@ -18,15 +18,15 @@ void buildDistLookupMaps(const NumericMatrix& dist_mat,
     int num_rows = dist_mat_rownames.size();
     int num_cols = dist_mat_colnames.size();
 
-    rows_map.clear();
-    cols_map.clear();
+    row_idx.fill(-1);
+    col_idx.fill(-1);
 
     for (int i = 0; i < num_rows; i++) {
         std::string this_row = as<std::string>(dist_mat_rownames[i]);
         if (this_row.empty()) {
             throw std::range_error("Empty row name in dist_mat.");
         }
-        rows_map[this_row] = i;
+        row_idx[static_cast<unsigned char>(this_row[0])] = i;
     }
 
     for (int i = 0; i < num_cols; i++) {
@@ -34,15 +34,23 @@ void buildDistLookupMaps(const NumericMatrix& dist_mat,
         if (this_col.empty()) {
             throw std::range_error("Empty column name in dist_mat.");
         }
-        cols_map[this_col] = i;
+        col_idx[static_cast<unsigned char>(this_col[0])] = i;
     }
 }
 
-double seqDistWithMaps(const std::string& seq1,
-                       const std::string& seq2,
-                       const NumericMatrix& dist_mat,
-                       const std::map<std::string, int>& rows_map,
-                       const std::map<std::string, int>& cols_map) {
+void encodeSequenceToInt(const std::string& seq,
+                         std::vector<unsigned char>& encoded) {
+    encoded.resize(seq.size());
+    for (size_t i = 0; i < seq.size(); i++) {
+        encoded[i] = static_cast<unsigned char>(seq[i]);
+    }
+}
+
+double seqDistWithMaps(const std::vector<unsigned char>& seq1,
+                       const std::vector<unsigned char>& seq2,
+                          const NumericMatrix& dist_mat,
+                          const std::array<int, 256>& row_idx,
+                          const std::array<int, 256>& col_idx) {
     int len_seq1 = seq1.size();
     int len_seq2 = seq2.size();
 
@@ -55,23 +63,13 @@ double seqDistWithMaps(const std::string& seq1,
     double d_sum = 0;
 
     for (int i = 0; i < len_seq1; i++) {
-        int r_idx;
-        std::string row_string;
-        row_string += static_cast<char>(seq1[i]);
-        auto search_row = rows_map.find(row_string);
-        if (search_row != rows_map.end()) {
-            r_idx = search_row->second;
-        } else {
+        int r_idx = row_idx[seq1[i]];
+        if (r_idx < 0) {
             throw std::range_error("Character not found in dist_mat.");
         }
 
-        int c_idx;
-        std::string col_string;
-        col_string += static_cast<char>(seq2[i]);
-        auto search_col = cols_map.find(col_string);
-        if (search_col != cols_map.end()) {
-            c_idx = search_col->second;
-        } else {
+        int c_idx = col_idx[seq2[i]];
+        if (c_idx < 0) {
             throw std::range_error("Character not found in dist_mat.");
         }
 
@@ -221,10 +219,14 @@ LogicalMatrix pairwiseEqual(StringVector seq) {
 // [[Rcpp::export]]
 double seqDistRcpp(std::string seq1, std::string seq2, 
                    NumericMatrix dist_mat) {
-    std::map<std::string, int> rows_map;
-    std::map<std::string, int> cols_map;
-    buildDistLookupMaps(dist_mat, rows_map, cols_map);
-    return seqDistWithMaps(seq1, seq2, dist_mat, rows_map, cols_map);
+    std::array<int, 256> row_idx;
+    std::array<int, 256> col_idx;
+    buildDistLookup(dist_mat, row_idx, col_idx);
+    std::vector<unsigned char> seq1_int;
+    std::vector<unsigned char> seq2_int;
+    encodeSequenceToInt(seq1, seq1_int);
+    encodeSequenceToInt(seq2, seq2_int);
+    return seqDistWithMaps(seq1_int, seq2_int, dist_mat, row_idx, col_idx);
 }
 
 
@@ -235,21 +237,22 @@ NumericMatrix pairwiseDistRcpp(StringVector seq, NumericMatrix dist_mat) {
     NumericMatrix rmat(seq.length(), seq.length());
 
     int n_seq = seq.length();
-    std::vector<std::string> seq_cpp(n_seq);
+    std::vector<std::vector<unsigned char>> seq_int(n_seq);
     for (int i = 0; i < n_seq; i++) {
-        seq_cpp[i] = as<std::string>(seq[i]);
+        std::string seq_i = as<std::string>(seq[i]);
+        encodeSequenceToInt(seq_i, seq_int[i]);
     }
 
-    std::map<std::string, int> rows_map;
-    std::map<std::string, int> cols_map;
-    buildDistLookupMaps(dist_mat, rows_map, cols_map);
+    std::array<int, 256> row_idx;
+    std::array<int, 256> col_idx;
+    buildDistLookup(dist_mat, row_idx, col_idx);
     
     for (int i = 0; i < rmat.nrow(); i++) {
         for (int j = 0; j < i; j++) {
-            const std::string& row_seq = seq_cpp[i];
-            const std::string& col_seq = seq_cpp[j];
+            const std::vector<unsigned char>& row_seq = seq_int[i];
+            const std::vector<unsigned char>& col_seq = seq_int[j];
 
-            double distance = seqDistWithMaps(row_seq, col_seq, dist_mat, rows_map, cols_map);
+            double distance = seqDistWithMaps(row_seq, col_seq, dist_mat, row_idx, col_idx);
             
             // write to output matrix
             rmat(i,j) = distance;
@@ -275,18 +278,19 @@ NumericMatrix nonsquareDistRcpp(StringVector seq, NumericVector indx, NumericMat
     m = indx.size(); //number of rows
     n = seq.size();  //number of columns
 
-    std::vector<std::string> seq_cpp(n);
+    std::vector<std::vector<unsigned char>> seq_int(n);
     for (i = 0; i < n; i++) {
-        seq_cpp[i] = as<std::string>(seq[i]);
+        std::string seq_i = as<std::string>(seq[i]);
+        encodeSequenceToInt(seq_i, seq_int[i]);
     }
 
     // allocate the main matrix
     NumericMatrix rmat(m,n);
     std::fill(rmat.begin(), rmat.end(), NA_REAL);
 
-    std::map<std::string, int> rows_map;
-    std::map<std::string, int> cols_map;
-    buildDistLookupMaps(dist_mat, rows_map, cols_map);
+    std::array<int, 256> row_idx;
+    std::array<int, 256> col_idx;
+    buildDistLookup(dist_mat, row_idx, col_idx);
 
     // sort and push indices back by 1 to match c++ indexing
     std::sort(indx.begin(), indx.end());
@@ -299,13 +303,13 @@ NumericMatrix nonsquareDistRcpp(StringVector seq, NumericVector indx, NumericMat
     // begin filling rmat
     for (i = 0; i < m; i++) {
         int row_id = indx[i];
-        const std::string& row_seq = seq_cpp[row_id];
+        const std::vector<unsigned char>& row_seq = seq_int[row_id];
         for (j = 0; j < n; j++) {
             if (!R_IsNA(rmat(i,j))) continue;
             if (row_id == j) rmat(i,j) = 0;
             else {
-                const std::string& col_seq = seq_cpp[j];
-                rmat(i,j) = seqDistWithMaps(row_seq, col_seq, dist_mat, rows_map, cols_map);
+                const std::vector<unsigned char>& col_seq = seq_int[j];
+                rmat(i,j) = seqDistWithMaps(row_seq, col_seq, dist_mat, row_idx, col_idx);
                 if (pos[j] < m) rmat(pos[j],indx[i]) = rmat(i,j);
             }
         }


### PR DESCRIPTION
I hope it is ok to open a PR. I worked on this code for a moment and thought it's best to contribute it upstream here.

I had a look at the distance computation C++ code and noticed that for `pairwiseDistRcpp` it is essentially a looped call to `seqDistRcpp`. 

Inside of `seqDistRcpp` a `rows_map` is created each time. The input to it is only `dist_mat` which is the same for each call.

As such I think we can move the creation of `rows_map` outside of the loop and pass it to `seqDistRcpp` to save computation time.

I did this in this PR and called the function `buildDistLookup`. 

Instead of calling `seqDistRcpp` in a loop, we now call `buildDistLookup` once and then call `seqDistWithMaps` inside the loop. This leads to a 1.2x to 1.6x speedup on the `pairwiseDist` function. Which is not much but it is free.

A bigger performance gain can be had by moving from String operations to Integers. But this comes with a memory cost.
As a new representation of each sequence is created in memory.

The memory cost should be moderate as each sequence is converted only once and then the distance lookup is done on integers. 

By using integers I see a speedup of around 19x-27x on the `pairwiseDist` function. This is a much more significant speedup and I think its worths considering this change. 


I tested this by calling the R function directly:

```R
sequences <- # generated random sequences
dist_lookup <- getDNAMatrix(gap = -1)
system.time(pairwiseDist(sequences, dist_lookup))
```

I confirmed that the resulting distances are identical to the previous version but would appreciate independent confirmation of this. I do not want to introduce a bug in the distance calculation :D

I came across this as I was using `distToNearest` in `shazam`. I know that the `pairwiseDist` is also used in `scoper` but I did not test if this change impacts that code noticably.


For `distToNearest` I ran it on 151k rows from a OAS dataset ("https://opig.stats.ox.ac.uk/webapps/ngsdb/unpaired/Bashford_2013/csv/ERR220445_Heavy_Bulk.csv.gz") (I prefixed locus with IG [H->IGH] to make the dataset runnable). The master branch took 57 seconds to compute. While the patch branch took 35 seconds to compute.

I ran:
```R
time_start = Sys.time()
dist <- distToNearest(db, 
    sequenceColumn="junction", 
    vCallColumn="v_call", 
    jCallColumn="j_call", 
    model="ham", 
    first=FALSE, 
    VJthenLen=TRUE, 
    normalize="len")
time_end = Sys.time()
elapsed_time = time_end - time_start
message("Elapsed time: ", elapsed_time)
```

While I have experience writing C++ and also using Rcpp, I have made use of LLMs to help me do this C++ adjustment. With all the discussions around this, I feel its worth mentioning this.

Let me know if there is anything I should do for you to review this PR. I am happy to make adjustments as needed.


I ran the testhat tests but it seems to me that the testsuite is not 100% maintained. In any case I see no regression between master and this PR. But master does fail on testDiversity.

```
✔ | F W  S  OK | Context                                                       
✔ |         67 | testAlignment                                                 
✖ | 1       35 | testAminoAcids                                                
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Error (testAminoAcids.R:10:5): countOccurrences0
Error in `countOccurrences("STSTSTS", "STS")`: konnte Funktion "countOccurrences" nicht finden
Backtrace:                                                                     
    ▆                                                                          
 1. └─testthat::expect_equal(countOccurrences("STSTSTS", "STS"), 2) at testAminoAcids.R:10:5
 2.   └─testthat::quasi_label(enquo(object), label)                            
 3.     └─rlang::eval_bare(expr, quo_get_env(quo))
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔ |          4 | testCore                                                      
✖ | 12    2 110 | testDiversity [3.8s]                                         
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```