### PR TITLE
Adds a `fields` argument to `collapseDuplicates` and fixes the `ignore` argument, which was never used. Closes #110. Fixes #137.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+Version 1.4.3.999: Unreleased
+-------------------------------------------------------------------------------
+
+Sequence:
+
++ Added the `fields` argument to `collapseDuplicates`, specifying columns 
+  (e.g. `c_call`) whose values must match for sequences to be collapsed 
+  together.
+
 Version 1.4.3: April 29, 2026
 -------------------------------------------------------------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@ Sequence:
 + Added the `fields` argument to `collapseDuplicates`, specifying columns 
   (e.g. `c_call`) whose values must match for sequences to be collapsed 
   together.
++ Fixed the `ignore` argument of `collapseDuplicates`, which was never used. 
+  Sequence equality was always tested with the default 
+  `c("N", "-", ".", "?")`.
++ Added the `ignore` argument to `pairwiseEqual`, which previously always used 
+  the `seqEqual` default of `c("N", "-", ".", "?")`.
 
 Version 1.4.3: April 29, 2026
 -------------------------------------------------------------------------------

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -38,25 +38,32 @@ seqEqual <- function(seq1, seq2, ignore = as.character( c("N","-",".","?"))) {
 #' \code{pairwiseEqual} determined pairwise equivalence between a pairs in a 
 #' set of sequences, excluding ambiguous positions (Ns and gaps).
 #'
-#' @param    seq  character vector containing a DNA sequences.
+#' @param    seq     character vector containing a DNA sequences.
+#' @param    ignore  vector of characters to ignore when testing for equality.
+#'                   Default is to ignore c("N","-",".","?")
 #'
-#' @return   A logical matrix of equivalence between each entry in \code{seq}. 
+#' @return   A logical matrix of equivalence between each entry in \code{seq}.
 #'           Values are \code{TRUE} when sequences are equivalent and \code{FALSE}
 #'           when they are not.
-#' 
+#'
 #' @seealso  Uses \link{seqEqual} for testing equivalence between pairs.
 #'           See \link{pairwiseDist} for generating a sequence distance matrix.
-#'           
+#'
 #' @examples
 #' # Gaps and Ns will match any character
 #' seq <- c(A="ATGGC", B="ATGGG", C="ATGGG", D="AT--C", E="NTGGG")
 #' d <- pairwiseEqual(seq)
 #' rownames(d) <- colnames(d) <- seq
 #' d
-#' 
+#'
+#' # Ignore only Ns, so that gaps are not treated as matching any character
+#' d <- pairwiseEqual(seq, ignore="N")
+#' rownames(d) <- colnames(d) <- seq
+#' d
+#'
 #' @export
-pairwiseEqual <- function(seq) {
-    .Call(`_alakazam_pairwiseEqual`, seq)
+pairwiseEqual <- function(seq, ignore = as.character( c("N","-",".","?"))) {
+    .Call(`_alakazam_pairwiseEqual`, seq, ignore)
 }
 
 seqDistRcpp <- function(seq1, seq2, dist_mat) {

--- a/R/Sequence.R
+++ b/R/Sequence.R
@@ -246,6 +246,7 @@ collapseDuplicates <- function(data, id="sequence_id", seq="sequence_alignment",
     # all NA column, which is a valid single group for the purposes of fields.
     # Columns that don't exist are dropped, so that fields is empty, and the data
     # collapsed as a single group, when none of them are found.
+    fields <- unique(fields)
     missing_fields <- setdiff(fields, names(data))
     if (length(missing_fields) > 0) {
         warning("The column(s) ", paste(missing_fields, collapse=", "),

--- a/R/Sequence.R
+++ b/R/Sequence.R
@@ -226,6 +226,13 @@ collapseDuplicates <- function(data, id="sequence_id", seq="sequence_alignment",
     if (any(duplicated(data[[id]]))) {
         stop("All values in the id column are not unique")
     }
+    # Only the first character of each ignore value is used when testing equality
+    if (!is.character(ignore)) {
+        stop("The ignore argument must be a character vector")
+    }
+    if (any(stri_length(ignore) > 1, na.rm=TRUE)) {
+        warning("Only the first character of each value in ignore is used.")
+    }
     # Verify column classes and exit if they are incorrect
     if (!is.null(text_fields)) {
         if (!all(sapply(subset(data, select=text_fields), is.character))) {
@@ -372,7 +379,8 @@ collapseDuplicates <- function(data, id="sequence_id", seq="sequence_alignment",
         cat("\n")
     }
     
-    # Define function to count informative positions in sequences
+    # Define function to count informative positions in sequences.
+    # Independent of ignore, which defines equality, not information content.
     .informativeLength <- function(x) {
         stri_length(gsub("[N\\-\\.\\?]", "", x, perl=TRUE))
     }
@@ -404,7 +412,7 @@ collapseDuplicates <- function(data, id="sequence_id", seq="sequence_alignment",
     
     # Build distance matrix
     exact_duplicates <- any(duplicated(data[[seq]]))
-    d_mat <- pairwiseEqual(unique(data[[seq]]))
+    d_mat <- pairwiseEqual(unique(data[[seq]]), ignore=ignore)
     colnames(d_mat) <- rownames(d_mat) <- unique(data[[seq]])
     n_uniqueseq <- nrow(d_mat)
     

--- a/R/Sequence.R
+++ b/R/Sequence.R
@@ -283,10 +283,12 @@ collapseDuplicates <- function(data, id="sequence_id", seq="sequence_alignment",
                                          seq_fields=seq_fields, add_count=add_count,
                                          ignore=ignore, sep=sep, dry=dry, verbose=verbose)
         if (dry) {
-            # collapse_id restarts at 1 in every group; shift to keep them unique.
-            # The ids within a group are bounded by the number of sequences in it.
+            # collapse_id restarts at 1 in every group; shift by the previous
+            # group's actual max id (not its row count) so ids stay unique
+            # across groups with no gaps.
+            local_max <- .maxCollapseId(res[["collapse_id"]])
             res[["collapse_id"]] <- .offsetCollapseId(res[["collapse_id"]], id_offset)
-            id_offset <- id_offset + length(group_rows[[i]])
+            id_offset <- id_offset + local_max
         }
         group_list[[i]] <- res
     }

--- a/R/Sequence.R
+++ b/R/Sequence.R
@@ -103,17 +103,27 @@ getAAMatrix <- function(gap=0) {
 #'                        retained. Where a non-informative character is one of 
 #'                        \code{c("N", "-", ".", "?")}. Note, this is distinct from the 
 #'                        \code{seq} parameter which is used to determine duplicates.
-#' @param    add_count    if \code{TRUE} add the column \code{collpase_count} that 
-#'                        indicates the number of sequences that were collapsed to build 
+#' @param    add_count    if \code{TRUE} add the column \code{collpase_count} that
+#'                        indicates the number of sequences that were collapsed to build
 #'                        each unique entry.
+#' @param    fields       character vector of additional column names used to group
+#'                        sequences prior to identifying duplicates. If specified,
+#'                        sequences will only be collapsed together if they are
+#'                        equivalent in the \code{seq} column and also share identical
+#'                        values in every one of the \code{fields} columns (see Details).
+#'                        Columns that are not found in \code{data} are ignored, with a
+#'                        warning; if none of them are found, all sequences are collapsed
+#'                        together as if \code{fields=NULL}.
 #' @param    ignore       vector of characters to ignore when testing for equality.
 #' @param    sep          character to use for delimiting collapsed annotations in the 
 #'                        \code{text_fields} columns. Defines both the input and output 
 #'                        delimiter.
 #' @param    dry          if \code{TRUE} perform dry run. Only labels the sequences without 
 #'                        collapsing them.
-#' @param    verbose      if \code{TRUE} report the number input, discarded and output 
-#'                        sequences; if \code{FALSE} process sequences silently.
+#' @param    verbose      if \code{TRUE} report the number input, discarded and output
+#'                        sequences; if \code{FALSE} process sequences silently. When
+#'                        \code{fields} is specified, one report is printed for each
+#'                        group of sequences.
 #'                        
 #' @return   A modified \code{data} data.frame with duplicate sequences removed and 
 #'           annotation fields collapsed if \code{dry=FALSE}. If \code{dry=TRUE}, 
@@ -132,10 +142,20 @@ getAAMatrix <- function(gap=0) {
 #' in the duplicate cluster. Sequence annotations, specified by \code{seq_fields}, are 
 #' collapsed by retaining the first sequence with the fewest number of N characters.
 #' 
-#' Columns that are not specified in either \code{text_fields}, \code{num_fields}, or 
-#' \code{seq_fields} will be retained, but the value will be chosen from a random entry 
+#' Columns that are not specified in either \code{text_fields}, \code{num_fields}, or
+#' \code{seq_fields} will be retained, but the value will be chosen from a random entry
 #' amongst all sequences in a cluster of duplicates.
-#' 
+#'
+#' If \code{fields} is specified, sequences are first grouped by the unique combinations
+#' of values in the \code{fields} columns, and duplicates are then identified separately
+#' within each group. As a result, sequences that are otherwise identical, but differ in
+#' one or more \code{fields} columns (for example, distinct \code{sample_id} or \code{c_call} isotype
+#' assignments), are kept as separate entries rather than being collapsed together.
+#' Sequences with an \code{NA} value in a \code{fields} column are grouped together.
+#' When \code{fields} is specified, the returned entries are ordered as they appeared
+#' in the input, and, if \code{dry=TRUE}, the \code{collapse_id} values are unique
+#' across groups and returned as character values.
+#'
 #' An ambiguous sequence is one that can be assigned to two different clusters, wherein
 #' the ambiguous sequence is equivalent to two sequences which are themselves 
 #' non-equivalent. Ambiguous sequences arise due to ambiguous characters at positions that
@@ -185,9 +205,13 @@ getAAMatrix <- function(gap=0) {
 #'                    sep="/", verbose=TRUE)
 #' 
 #' # Add count of duplicates
-#' collapseDuplicates(db, text_fields=c("c_call", "sample_id"), num_fields="duplicate_count", 
+#' collapseDuplicates(db, text_fields=c("c_call", "sample_id"), num_fields="duplicate_count",
 #'                    add_count=TRUE, verbose=TRUE)
-#' 
+#'
+#' # Use fields to prevent collapsing sequences that differ in sample_id or c_call
+#' collapseDuplicates(db, num_fields="duplicate_count",
+#'                    fields=c("sample_id", "c_call"), add_count=TRUE, verbose=TRUE)
+#'
 #' # Masking ragged ends may impact duplicate removal
 #' db$sequence_alignment <- maskSeqEnds(db$sequence_alignment)
 #' collapseDuplicates(db, text_fields=c("c_call", "sample_id"), num_fields="duplicate_count", 
@@ -196,7 +220,7 @@ getAAMatrix <- function(gap=0) {
 #' @export
 collapseDuplicates <- function(data, id="sequence_id", seq="sequence_alignment",
                                text_fields=NULL, num_fields=NULL, seq_fields=NULL,
-                               add_count=FALSE, ignore=c("N", "-", ".", "?"), 
+                               add_count=FALSE, fields=NULL, ignore=c("N", "-", ".", "?"),
                                sep=",", dry=FALSE, verbose=FALSE) {
     # Stop if ids are not unique
     if (any(duplicated(data[[id]]))) {
@@ -218,12 +242,122 @@ collapseDuplicates <- function(data, id="sequence_id", seq="sequence_alignment",
             stop("All seq_fields columns must be of type 'character'")
         }
     }
+    # Existence check only. checkColumns() is not used here because it rejects an
+    # all NA column, which is a valid single group for the purposes of fields.
+    # Columns that don't exist are dropped, so that fields is empty, and the data
+    # collapsed as a single group, when none of them are found.
+    missing_fields <- setdiff(fields, names(data))
+    if (length(missing_fields) > 0) {
+        warning("The column(s) ", paste(missing_fields, collapse=", "),
+                " were not found. Not grouping by these fields.")
+        fields <- setdiff(fields, missing_fields)
+    }
     seq_len <- stri_length(data[[seq]])
     if (any(seq_len != seq_len[1])) {
-        warning("All sequences are not the same length for data with first ", 
+        warning("All sequences are not the same length for data with first ",
                 id, " = ", data[[id]][1])
     }
-    
+
+    # Collapse the whole input as a single group
+    if (is.null(fields) || length(fields) == 0 || nrow(data) <= 1) {
+        return(.collapseDuplicatesSingle(data, id=id, seq=seq, text_fields=text_fields,
+                                         num_fields=num_fields, seq_fields=seq_fields,
+                                         add_count=add_count, ignore=ignore, sep=sep,
+                                         dry=dry, verbose=verbose))
+    }
+
+    # Split rows by the unique combinations of the fields values.
+    # NA values define their own group.
+    group_rows <- dplyr::group_rows(dplyr::group_by(data, !!!rlang::syms(fields)))
+    if (length(unlist(group_rows, use.names=FALSE)) != nrow(data)) {
+        stop("Failed to group all rows by the fields columns in collapseDuplicates")
+    }
+
+    # Collapse duplicates within each group
+    group_list <- vector("list", length(group_rows))
+    id_offset <- 0
+    for (i in seq_along(group_rows)) {
+        res <- .collapseDuplicatesSingle(data[group_rows[[i]], , drop=FALSE], id=id, seq=seq,
+                                         text_fields=text_fields, num_fields=num_fields,
+                                         seq_fields=seq_fields, add_count=add_count,
+                                         ignore=ignore, sep=sep, dry=dry, verbose=verbose)
+        if (dry) {
+            # collapse_id restarts at 1 in every group; shift to keep them unique.
+            # The ids within a group are bounded by the number of sequences in it.
+            res[["collapse_id"]] <- .offsetCollapseId(res[["collapse_id"]], id_offset)
+            id_offset <- id_offset + length(group_rows[[i]])
+        }
+        group_list[[i]] <- res
+    }
+
+    # Write the annotations back into the unmodified input
+    if (dry) {
+        out <- data
+        extra_cols <- setdiff(names(group_list[[1]]), names(data))
+        out[["collapse_id"]] <- NA_character_
+        out[["collapse_class"]] <- NA_character_
+        out[["collapse_pass"]] <- NA
+        if ("collapse_count" %in% extra_cols) { out[["collapse_count"]] <- NA_real_ }
+        for (res in group_list) {
+            pos <- match(res[[id]], out[[id]])
+            for (f in extra_cols) { out[[f]][pos] <- res[[f]] }
+        }
+        return(out)
+    }
+
+    # Combine the groups and restore the input row order
+    out <- as.data.frame(bind_rows(group_list))
+    out <- out[order(match(out[[id]], data[[id]])), , drop=FALSE]
+    rownames(out) <- NULL
+
+    return(out)
+}
+
+
+# Shift collapse_id values by an offset, handling comma delimited ids
+#
+# @param   x       vector of collapse_id values.
+# @param   offset  integer to add to each id.
+# @return  A character vector of shifted ids.
+.offsetCollapseId <- function(x, offset) {
+    parts <- strsplit(as.character(x), ",", fixed=TRUE)
+    vapply(parts, function(p) {
+        if (length(p) == 0 || anyNA(p)) { return(NA_character_) }
+        paste(as.integer(p) + offset, collapse=",")
+    }, character(1))
+}
+
+
+# Find the largest collapse_id
+#
+# @param   x  vector of collapse_id values.
+# @return  The largest id as an integer, or 0 if there are none.
+.maxCollapseId <- function(x) {
+    v <- suppressWarnings(as.integer(unlist(strsplit(as.character(x), ",", fixed=TRUE))))
+    if (length(v) == 0 || all(is.na(v))) { return(0L) }
+
+    return(max(v, na.rm=TRUE))
+}
+
+
+# Collapse duplicate sequences within a single group
+#
+# The body of collapseDuplicates.
+#
+# @param   data         data.frame of sequences belonging to one group.
+# @param   id           name of the column containing sequence identifiers.
+# @param   seq          name of the column containing DNA sequences.
+# @param   text_fields  character vector of textual columns to collapse.
+# @param   num_fields   vector of numeric columns to collapse.
+# @param   seq_fields   vector of nucleotide sequence columns to collapse.
+# @param   add_count    if \code{TRUE} add the column \code{collapse_count}.
+# @param   ignore       vector of characters to ignore when testing for equality.
+# @param   sep          character to use for delimiting collapsed annotations.
+# @param   dry          if \code{TRUE} perform dry run.
+# @param   verbose      if \code{TRUE} report the collapse counts.
+# @return  A modified \code{data} data.frame, as described for collapseDuplicates.
+.collapseDuplicatesSingle <- function(data, id, seq, text_fields, num_fields, seq_fields,
+                                      add_count, ignore, sep, dry, verbose) {
     # Define verbose reporting function
     .printVerbose <- function(n_total, n_unique, n_discard) {
         cat(" FUNCTION> collapseDuplicates\n", sep="")

--- a/src/RcppDistance.cpp
+++ b/src/RcppDistance.cpp
@@ -85,25 +85,33 @@ bool seqEqual(std::string seq1, std::string seq2,
 //' \code{pairwiseEqual} determined pairwise equivalence between a pairs in a 
 //' set of sequences, excluding ambiguous positions (Ns and gaps).
 //'
-//' @param    seq  character vector containing a DNA sequences.
+//' @param    seq     character vector containing a DNA sequences.
+//' @param    ignore  vector of characters to ignore when testing for equality.
+//'                   Default is to ignore c("N","-",".","?")
 //'
-//' @return   A logical matrix of equivalence between each entry in \code{seq}. 
+//' @return   A logical matrix of equivalence between each entry in \code{seq}.
 //'           Values are \code{TRUE} when sequences are equivalent and \code{FALSE}
 //'           when they are not.
-//' 
+//'
 //' @seealso  Uses \link{seqEqual} for testing equivalence between pairs.
 //'           See \link{pairwiseDist} for generating a sequence distance matrix.
-//'           
+//'
 //' @examples
 //' # Gaps and Ns will match any character
 //' seq <- c(A="ATGGC", B="ATGGG", C="ATGGG", D="AT--C", E="NTGGG")
 //' d <- pairwiseEqual(seq)
 //' rownames(d) <- colnames(d) <- seq
 //' d
-//' 
+//'
+//' # Ignore only Ns, so that gaps are not treated as matching any character
+//' d <- pairwiseEqual(seq, ignore="N")
+//' rownames(d) <- colnames(d) <- seq
+//' d
+//'
 //' @export
 // [[Rcpp::export]]
-LogicalMatrix pairwiseEqual(StringVector seq) {
+LogicalMatrix pairwiseEqual(StringVector seq,
+                            CharacterVector ignore=CharacterVector::create("N","-",".","?")) {
     
     // allocate the matrix we will return
     LogicalMatrix rmat(seq.length(), seq.length());
@@ -115,7 +123,7 @@ LogicalMatrix pairwiseEqual(StringVector seq) {
             std::string row_seq = as<std::string>(seq[i]);
             std::string col_seq = as<std::string>(seq[j]);
             
-            bool is_equal = seqEqual(row_seq, col_seq);
+            bool is_equal = seqEqual(row_seq, col_seq, ignore);
             
             // write to output matrix
             rmat(i,j) = is_equal;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -24,13 +24,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // pairwiseEqual
-LogicalMatrix pairwiseEqual(StringVector seq);
-RcppExport SEXP _alakazam_pairwiseEqual(SEXP seqSEXP) {
+LogicalMatrix pairwiseEqual(StringVector seq, CharacterVector ignore);
+RcppExport SEXP _alakazam_pairwiseEqual(SEXP seqSEXP, SEXP ignoreSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< StringVector >::type seq(seqSEXP);
-    rcpp_result_gen = Rcpp::wrap(pairwiseEqual(seq));
+    Rcpp::traits::input_parameter< CharacterVector >::type ignore(ignoreSEXP);
+    rcpp_result_gen = Rcpp::wrap(pairwiseEqual(seq, ignore));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -136,7 +137,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_alakazam_seqEqual", (DL_FUNC) &_alakazam_seqEqual, 3},
-    {"_alakazam_pairwiseEqual", (DL_FUNC) &_alakazam_pairwiseEqual, 1},
+    {"_alakazam_pairwiseEqual", (DL_FUNC) &_alakazam_pairwiseEqual, 2},
     {"_alakazam_seqDistRcpp", (DL_FUNC) &_alakazam_seqDistRcpp, 3},
     {"_alakazam_pairwiseDistRcpp", (DL_FUNC) &_alakazam_pairwiseDistRcpp, 2},
     {"_alakazam_nonsquareDistRcpp", (DL_FUNC) &_alakazam_nonsquareDistRcpp, 3},

--- a/tests/testthat/testSequence.R
+++ b/tests/testthat/testSequence.R
@@ -298,6 +298,26 @@ test_that("seqEqual", {
     expect_false(seqEqual("AT--T", "ATGGC", ignore="N"))
 })
 
+#### pairwiseEqual ####
+
+test_that("pairwiseEqual", {
+    seq <- c(A="ATGGC", B="ATGGG", C="ATGGG", D="AT--C", E="NTGGG")
+
+    # Gaps and Ns match any character
+    obs <- pairwiseEqual(seq)
+    expect_equal(obs[, "A"], c(A=TRUE, B=FALSE, C=FALSE, D=TRUE, E=FALSE))
+    expect_equal(obs[, "E"], c(A=FALSE, B=TRUE, C=TRUE, D=FALSE, E=TRUE))
+
+    # Ignoring only Ns means gaps must match exactly
+    obs <- pairwiseEqual(seq, ignore="N")
+    expect_equal(obs[, "A"], c(A=TRUE, B=FALSE, C=FALSE, D=FALSE, E=FALSE))
+    expect_equal(obs[, "E"], c(A=FALSE, B=TRUE, C=TRUE, D=FALSE, E=TRUE))
+
+    # An empty ignore requires exact identity
+    obs <- pairwiseEqual(seq, ignore=character(0))
+    expect_equal(obs[, "B"], c(A=FALSE, B=TRUE, C=TRUE, D=FALSE, E=FALSE))
+})
+
 #### translateDNA ####
 
 test_that("translateDNA", {
@@ -579,6 +599,57 @@ test_that("collapseDuplicates: fields", {
     expect_output(collapseDuplicates(db_amb, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
                                      fields="TYPE", verbose=TRUE),
                   "FUNCTION> collapseDuplicates")
+})
+
+test_that("collapseDuplicates: ignore", {
+    # A differs from C only at gap positions, and from B only at an N position
+    db_ig <- data.frame(SEQUENCE_ID=c("A", "B", "C"),
+                        SEQUENCE_IMGT=c("CCCCTGGG", "CCCCTGGN", "CCCCTG--"),
+                        stringsAsFactors=FALSE)
+
+    # Default ignores both Ns and gaps, so all three are duplicates
+    expect_equal(collapseDuplicates(db_ig, id="SEQUENCE_ID", seq="SEQUENCE_IMGT")$SEQUENCE_ID,
+                 "A")
+
+    # Ignoring only Ns keeps the gapped sequence separate
+    obs <- collapseDuplicates(db_ig, id="SEQUENCE_ID", seq="SEQUENCE_IMGT", ignore="N")
+    expect_equal(sort(obs$SEQUENCE_ID), c("A", "C"))
+
+    # Ignoring both again collapses everything
+    expect_equal(collapseDuplicates(db_ig, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                    ignore=c("N", "-"))$SEQUENCE_ID,
+                 "A")
+
+    # An empty ignore requires exact identity
+    expect_equal(collapseDuplicates(db_ig, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                    ignore=character(0))$SEQUENCE_ID,
+                 c("A", "B", "C"))
+
+    # ignore is respected in the dry run
+    obs_dry <- collapseDuplicates(db_ig, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                  ignore="N", dry=TRUE)
+    expect_equal(obs_dry$collapse_class, c("duplicated", "duplicated", "unique"))
+    expect_equal(obs_dry$collapse_pass, c(TRUE, FALSE, TRUE))
+
+    # ignore does not change which sequence of a cluster is retained, which is
+    # always the one with the fewest N, -, . and ? characters
+    db_sf <- data.frame(SEQUENCE_ID=c("A", "B"),
+                        SEQUENCE_IMGT=c("CCCCTGGG", "CCCCTGGG"),
+                        GERMLINE_IMGT=c("AAAANNNN", "AAAAAA--"),
+                        stringsAsFactors=FALSE)
+    for (ig in list(c("N", "-", ".", "?"), "N", character(0))) {
+        expect_equal(collapseDuplicates(db_sf, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                        seq_fields="GERMLINE_IMGT", ignore=ig)$GERMLINE_IMGT,
+                     "AAAAAA--")
+    }
+
+    # Only the first character of each ignore value is used
+    expect_warning(collapseDuplicates(db_ig, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                      ignore="N-"),
+                   "first character")
+    expect_error(collapseDuplicates(db_ig, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                    ignore=1),
+                 "character vector")
 })
 
 #### extractVRegion ####

--- a/tests/testthat/testSequence.R
+++ b/tests/testthat/testSequence.R
@@ -484,7 +484,101 @@ test_that("collapseDuplicates", {
     expect_equal(col$SEQUENCE_ID, expect)
     col_dry <- collapseDuplicates(test, dry=T, id="SEQUENCE_ID", seq="SEQUENCE_IMGT")
     expect_equal(col_dry$SEQUENCE_ID[col_dry$collapse_pass], expect)
-    
+
+})
+
+test_that("collapseDuplicates: fields", {
+    db_f <- data.frame(SEQUENCE_ID=c("A", "B", "C"),
+                       SEQUENCE_IMGT=rep("CCCCTGGG", 3),
+                       TYPE=c("IgM", "IgG", "IgG"),
+                       COUNT=c(1, 2, 3),
+                       stringsAsFactors=FALSE)
+
+    # Identical sequences with a different TYPE are not collapsed together
+    obs <- collapseDuplicates(db_f, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                              num_fields="COUNT", fields="TYPE", add_count=TRUE)
+    expect_equal(nrow(obs), 2)
+    expect_equal(obs$SEQUENCE_ID, c("A", "B"))
+    expect_equal(obs$COUNT[obs$TYPE == "IgG"], 5)
+    expect_equal(obs$collapse_count[obs$TYPE == "IgG"], 2)
+    expect_equal(obs$collapse_count[obs$TYPE == "IgM"], 1)
+
+    # The same sequences are collapsed when fields is not specified
+    expect_equal(nrow(collapseDuplicates(db_f, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                         num_fields="COUNT")), 1)
+
+    # fields=NULL is identical to omitting fields
+    expect_equal(collapseDuplicates(db_f, id="SEQUENCE_ID", seq="SEQUENCE_IMGT", fields=NULL),
+                 collapseDuplicates(db_f, id="SEQUENCE_ID", seq="SEQUENCE_IMGT"))
+
+    # NA values in the TYPE column define their own group
+    db_na <- data.frame(SEQUENCE_ID=c("A", "B", "C", "D"),
+                        SEQUENCE_IMGT=rep("CCCCTGGG", 4),
+                        TYPE=c("IgM", NA, NA, "IgG"),
+                        COUNT=1:4,
+                        stringsAsFactors=FALSE)
+    obs <- collapseDuplicates(db_na, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                              num_fields="COUNT", fields="TYPE", add_count=TRUE)
+    expect_equal(nrow(obs), 3)
+    expect_true(any(is.na(obs$TYPE)))
+    expect_equal(obs$collapse_count[is.na(obs$TYPE)], 2)
+    expect_equal(sum(obs$COUNT), 10)
+    expect_equal(sum(obs$collapse_count), 4)
+
+    # Dry run returns the input, in the input order, with unique collapse_id values
+    obs_dry <- collapseDuplicates(db_na, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                  fields="TYPE", dry=TRUE)
+    expect_equal(nrow(obs_dry), nrow(db_na))
+    expect_equal(obs_dry$SEQUENCE_ID, db_na$SEQUENCE_ID)
+    expect_equal(obs_dry$TYPE, db_na$TYPE)
+    expect_equal(obs_dry$collapse_class, c("unique", "duplicated", "duplicated", "unique"))
+    expect_equal(sum(obs_dry$collapse_pass), 3)
+    expect_false(any(is.na(obs_dry$collapse_id)))
+    expect_equal(length(unique(obs_dry$collapse_id)), 3)
+    expect_equal(obs_dry$collapse_id[2], obs_dry$collapse_id[3])
+
+    # Ambiguous sequences are resolved within each group.
+    # D is ambiguous across the whole set, but is alone in the IgA group.
+    db_amb <- data.frame(SEQUENCE_ID=LETTERS[1:5],
+                         SEQUENCE_IMGT=c("CCCCTGGG", "CCCCTGGN", "NAACTGGN", "NNNCTGNN", "NAACTGNG"),
+                         TYPE=c("IgM", "IgG", "IgG", "IgA", "IgG"),
+                         COUNT=1:5,
+                         stringsAsFactors=FALSE)
+    expect_equal(collapseDuplicates(db_amb, id="SEQUENCE_ID", seq="SEQUENCE_IMGT")$SEQUENCE_ID,
+                 c("A", "C"))
+    obs <- collapseDuplicates(db_amb, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                              text_fields="TYPE", num_fields="COUNT", fields="TYPE")
+    expect_equal(obs$SEQUENCE_ID, c("A", "B", "C", "D"))
+    expect_equal(obs$COUNT[obs$SEQUENCE_ID == "C"], 8)
+    obs_dry <- collapseDuplicates(db_amb, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                  fields="TYPE", dry=TRUE)
+    expect_equal(obs_dry$SEQUENCE_ID, db_amb$SEQUENCE_ID)
+    expect_equal(obs_dry$collapse_class,
+                 c("unique", "unique", "duplicated", "unique", "duplicated"))
+    expect_equal(obs_dry$collapse_pass, c(TRUE, TRUE, TRUE, TRUE, FALSE))
+    expect_equal(length(unique(obs_dry$collapse_id)), 4)
+
+    # Multiple fields; COUNT is unique per row, so nothing is collapsed
+    obs <- collapseDuplicates(db_amb, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                              fields=c("TYPE", "COUNT"))
+    expect_equal(nrow(obs), 5)
+
+    # A missing fields column is dropped, with a warning
+    expect_warning(obs <- collapseDuplicates(db_f, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                             fields=c("TYPE", "NOT_A_COLUMN")),
+                   "not found")
+    expect_equal(obs$SEQUENCE_ID, c("A", "B"))
+
+    # If none of the fields are found, the data is collapsed as a single group
+    expect_warning(obs <- collapseDuplicates(db_f, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                             fields="NOT_A_COLUMN"),
+                   "not found")
+    expect_equal(obs, collapseDuplicates(db_f, id="SEQUENCE_ID", seq="SEQUENCE_IMGT"))
+
+    # One verbose report per group
+    expect_output(collapseDuplicates(db_amb, id="SEQUENCE_ID", seq="SEQUENCE_IMGT",
+                                     fields="TYPE", verbose=TRUE),
+                  "FUNCTION> collapseDuplicates")
 })
 
 #### extractVRegion ####


### PR DESCRIPTION
**`fields` (#110).** `collapseDuplicates(data, fields=c("sample_id", "c_call"))` identifies duplicates separately within each unique combination of the `fields` values, so sequences that are identical except for, say, their isotype are kept as separate entries instead of being collapsed with merged annotations.

**`ignore` (#137).** `collapseDuplicates` accepted `ignore` but never passed it on, because `pairwiseEqual` hardcoded `c("N", "-", ".", "?")`. `pairwiseEqual` now takes an `ignore` argument (defaulting to those characters, so existing calls are unaffected) and `collapseDuplicates` passes it through. This changes results for users who were providing a non-default ignore value: previously, the supplied value was silently ignored and the default was used; now, the supplied value is correctly applied.